### PR TITLE
Don't trigger events if user tries to write

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-keyboard-shortcuts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "React hook to attach keyboard shortcuts to the document",
   "author": "SAITS",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@ export type Shortcut = {
   keys: string[]
   onEvent: (event: ShortcutEvent) => void
   disabled?: boolean
-  skipPreventDefault?: boolean
 }
 
 export enum EventType {
@@ -15,14 +14,14 @@ export enum EventType {
 export enum ComboKey {
   ctrl = "ctrl",
   shift = "shift",
-  alt = "lat",
+  alt = "alt",
 }
 
 export type ShortcutEvent = KeyboardEvent | WheelEvent
 
 const ALLOWED_COMBO_KEYS = Object.keys(ComboKey)
 const ALLOWED_EVENTS = Object.keys(EventType)
-const SKIP_PREVENT_DEFAULT_FOR = ["INPUT", "TEXTAREA"]
+const EDITABLE_TAGS = ["INPUT", "TEXTAREA"]
 
 const throwError = (message: string): void =>
   console.error(`Error thrown for useKeyboardShortcuts: ${message}`)
@@ -111,17 +110,22 @@ export const useKeyboardShortcuts = (
       if (!valid || getKeyCode(keys[0]) !== event.code) return
     }
 
+    // If the targetted element is a input for example, and the user doesn't
+    // press ctrl or meta it probably means that they are trying to type in the
+    // input field
+    const writing =
+      EDITABLE_TAGS.includes(event.target && event.target["tagName"]) &&
+      !event.ctrlKey &&
+      !event.metaKey
+
     const shouldExecAction =
       !shortcut.disabled &&
+      !writing &&
       allComboKeysPressed(shortcut.keys, event) &&
       shortcutHasPrioroty(shortcut, event)
 
-    const shouldSkipPreventDefault =
-      shortcut.skipPreventDefault ||
-      SKIP_PREVENT_DEFAULT_FOR.includes(event.target && event.target["tagName"])
-
     if (shouldExecAction) {
-      if (!shouldSkipPreventDefault) event.preventDefault()
+      event.preventDefault()
       shortcut.onEvent(event)
     }
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ export type Shortcut = {
   keys: string[]
   onEvent: (event: ShortcutEvent) => void
   disabled?: boolean
+  skipPreventDefault?: boolean
 }
 
 export enum EventType {
@@ -21,6 +22,7 @@ export type ShortcutEvent = KeyboardEvent | WheelEvent
 
 const ALLOWED_COMBO_KEYS = Object.keys(ComboKey)
 const ALLOWED_EVENTS = Object.keys(EventType)
+const SKIP_PREVENT_DEFAULT_FOR = ["INPUT", "TEXTAREA"]
 
 const throwError = (message: string): void =>
   console.error(`Error thrown for useKeyboardShortcuts: ${message}`)
@@ -114,8 +116,12 @@ export const useKeyboardShortcuts = (
       allComboKeysPressed(shortcut.keys, event) &&
       shortcutHasPrioroty(shortcut, event)
 
+    const shouldSkipPreventDefault =
+      shortcut.skipPreventDefault ||
+      SKIP_PREVENT_DEFAULT_FOR.includes(event.target && event.target["tagName"])
+
     if (shouldExecAction) {
-      event.preventDefault()
+      if (!shouldSkipPreventDefault) event.preventDefault()
       shortcut.onEvent(event)
     }
   }


### PR DESCRIPTION
If we add a listener for `["shift", "minus"]` (`?`) and the user focuses an input element and tries to write a question mark our listener would trigger.

This PR makes it so that we don't execute events if the focused element is an `input` or `textarea` and `ctrl` or `cmd` is pressed