### PR TITLE
For single keys, check key before code value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-keyboard-shortcuts",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "React hook to attach keyboard shortcuts to the document",
   "author": "SAITS",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ const allComboKeysPressed = (keys: string[], event: ShortcutEvent) => {
   return true
 }
 
-const validateKeys = (keys: string[]) => {
+const validateKeys = (keys: string[]): boolean => {
   let errorMessage: string | null = null
 
   if (!keys.length)
@@ -46,7 +46,12 @@ const validateKeys = (keys: string[]) => {
       ALLOWED_COMBO_KEYS
     )} can be used. Found ${keys.length}: [${keys.map(key => `"${key}"`)}].`
 
-  return errorMessage ? throwError(errorMessage) : true
+  if (errorMessage) {
+    throwError(errorMessage)
+    return false
+  }
+
+  return true
 }
 
 const withoutComboKeys = (key: string) =>
@@ -106,8 +111,10 @@ export const useKeyboardShortcuts = (
     if (event instanceof KeyboardEvent) {
       const keys = shortcut.keys.filter(withoutComboKeys)
       const valid = validateKeys(keys)
+      const singleKey =
+        shortcut.keys.length === 1 && shortcut.keys[0] === event.key
 
-      if (!valid || getKeyCode(keys[0]) !== event.code) return
+      if (!valid || !(singleKey || getKeyCode(keys[0]) === event.code)) return
     }
 
     // If the targetted element is a input for example, and the user doesn't

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -16,6 +16,8 @@ const TestComponent = () => {
     { keys: ["?"], onEvent: () => appendCombination("?") },
     { keys: ["Shift", "Minus"], onEvent: () => appendCombination("shift + ?") },
     { keys: ["9"], onEvent: () => appendCombination("9") },
+    { keys: ["Shift", "9"], onEvent: () => appendCombination("shift + 9") },
+    { keys: ["alt", "a"], onEvent: () => appendCombination("alt + a") },
     {
       keys: ["ctrl", "a"],
       onEvent: () => appendCombination("ctrl + a"),
@@ -65,6 +67,20 @@ describe("useKeyboardShortcuts", () => {
 
     fireEvent.keyDown(document, { key: "?" })
     expect(await findByText("?")).toBeInTheDocument()
+  })
+
+  it("handles shift + number", async () => {
+    const { findByText } = render(<TestComponent />)
+
+    fireEvent.keyDown(document, { shiftKey: true, code: "Digit9" })
+    expect(await findByText("shift + 9")).toBeInTheDocument()
+  })
+
+  it("handles alt + char", async () => {
+    const { findByText } = render(<TestComponent />)
+
+    fireEvent.keyDown(document, { altKey: true, code: "KeyA" })
+    expect(await findByText("alt + a")).toBeInTheDocument()
   })
 
   it("handles ? even if shift is pressed (swedish keyboard layout for instance)", async () => {

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -13,7 +13,8 @@ const TestComponent = () => {
 
   useKeyboardShortcuts([
     { keys: ["a"], onEvent: () => appendCombination("a") },
-    { keys: ["Shift", "Minus"], onEvent: () => appendCombination("?") },
+    { keys: ["?"], onEvent: () => appendCombination("?") },
+    { keys: ["Shift", "Minus"], onEvent: () => appendCombination("shift + ?") },
     { keys: ["9"], onEvent: () => appendCombination("9") },
     {
       keys: ["ctrl", "a"],
@@ -62,8 +63,15 @@ describe("useKeyboardShortcuts", () => {
   it("handles ?", async () => {
     const { findByText } = render(<TestComponent />)
 
-    fireEvent.keyDown(document, { shiftKey: true, code: "Minus" })
+    fireEvent.keyDown(document, { key: "?" })
     expect(await findByText("?")).toBeInTheDocument()
+  })
+
+  it("handles ? even if shift is pressed (swedish keyboard layout for instance)", async () => {
+    const { findByText } = render(<TestComponent />)
+
+    fireEvent.keyDown(document, { shiftKey: true, code: "Minus" })
+    expect(await findByText("shift + ?")).toBeInTheDocument()
   })
 
   it("handles ctrl + char", async () => {


### PR DESCRIPTION
In order to capture `?` on a Swedish keyboard layout, you would have to add `["shift", "Minus"]`, and that would only capture `?` on Swedish keyboard layouts, so you have to add a bunch of different variations.

This PR makes it so that we check the `key` value of `KeyboardEvent` before we check the `code` value.