### PR TITLE
KeyboardEvent made Cypress e2e tests to fail

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -122,7 +122,7 @@ export const useKeyboardShortcuts = (
     // input field
     const writing =
       EDITABLE_TAGS.includes(event.target && event.target["tagName"]) &&
-      (event instanceof KeyboardEvent && event.code !== "Escape") &&
+      ('code' in event && event.code !== "Escape") &&
       !event.ctrlKey &&
       !event.metaKey
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,7 @@ const throwError = (message: string): void =>
 
 const allComboKeysPressed = (keys: string[], event: ShortcutEvent) => {
   keys = keys.map(key => key.toLowerCase())
-  if (keys.includes("ctrl") && (!event.ctrlKey && !event.metaKey)) return false
+  if (keys.includes("ctrl") && !event.ctrlKey && !event.metaKey) return false
   if (keys.includes("shift") && !event.shiftKey) return false
   if (keys.includes("alt") && !event.altKey) return false
   return true
@@ -92,7 +92,7 @@ export const useKeyboardShortcuts = (
       )}. Found event: "${eventType}".`
     )
 
-  const shortcutHasPrioroty = (
+  const shortcutHasPriority = (
     inputShortcut: Shortcut,
     event: ShortcutEvent
   ) => {
@@ -118,10 +118,11 @@ export const useKeyboardShortcuts = (
     }
 
     // If the targetted element is a input for example, and the user doesn't
-    // press ctrl or meta it probably means that they are trying to type in the
+    // press ctrl or meta or escape it probably means that they are trying to type in the
     // input field
     const writing =
       EDITABLE_TAGS.includes(event.target && event.target["tagName"]) &&
+      event instanceof KeyboardEvent && event.code !== "Escape" &&
       !event.ctrlKey &&
       !event.metaKey
 
@@ -129,7 +130,7 @@ export const useKeyboardShortcuts = (
       !shortcut.disabled &&
       !writing &&
       allComboKeysPressed(shortcut.keys, event) &&
-      shortcutHasPrioroty(shortcut, event)
+      shortcutHasPriority(shortcut, event)
 
     if (shouldExecAction) {
       event.preventDefault()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,7 @@ const throwError = (message: string): void =>
 
 const allComboKeysPressed = (keys: string[], event: ShortcutEvent) => {
   keys = keys.map(key => key.toLowerCase())
-  if (keys.includes("ctrl") && !event.ctrlKey && !event.metaKey) return false
+  if (keys.includes("ctrl") && (!event.ctrlKey && !event.metaKey)) return false
   if (keys.includes("shift") && !event.shiftKey) return false
   if (keys.includes("alt") && !event.altKey) return false
   return true
@@ -122,7 +122,7 @@ export const useKeyboardShortcuts = (
     // input field
     const writing =
       EDITABLE_TAGS.includes(event.target && event.target["tagName"]) &&
-      event instanceof KeyboardEvent && event.code !== "Escape" &&
+      (event instanceof KeyboardEvent && event.code !== "Escape") &&
       !event.ctrlKey &&
       !event.metaKey
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -122,7 +122,7 @@ export const useKeyboardShortcuts = (
     // input field
     const writing =
       EDITABLE_TAGS.includes(event.target && event.target["tagName"]) &&
-      ('code' in event && event.code !== "Escape") &&
+      ("code" in event && event.code !== "Escape") &&
       !event.ctrlKey &&
       !event.metaKey
 

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -159,6 +159,29 @@ describe("useKeyboardShortcuts", () => {
     expect(await findByText("ctrl + shift + scroll")).toBeInTheDocument()
   })
 
+  it("ignores events when input element has focus, unless ctrl, meta or Escape is pressed", async () => {
+    const onEventMock = jest.fn()
+
+    const TestInputComponent = () => {
+      useKeyboardShortcuts([
+        { keys: ["a"], onEvent: onEventMock },
+        { keys: ["Escape"], onEvent: onEventMock },
+        { keys: ["ctrl", "a"], onEvent: onEventMock },
+      ])
+
+      return <input type="text" role="textbox" />
+    }
+    const { getByRole } = render(<TestInputComponent />)
+    const inputElem = getByRole("textbox")
+
+    fireEvent.keyDown(inputElem, { code: "KeyA" })
+    expect(onEventMock).not.toHaveBeenCalled()
+    fireEvent.keyDown(inputElem, { code: "Escape" })
+    expect(onEventMock).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(inputElem, { ctrlKey: true, code: "KeyA" })
+    expect(onEventMock).toHaveBeenCalledTimes(2)
+  })
+
   it("throws error when no shortcuts are given", async () => {
     console.error = jest.fn()
 


### PR DESCRIPTION
After bumping version to 2.2.1, we spotted an issue with cypress here:
https://github.com/SAITS/use-keyboard-shortcuts/pull/17/files#diff-38682f47b0cf12c516bc3714fc45d0fdL125

Cypress uses Event for keyboard events, and this was turning writing into false and the keyboard events were prevented, so typing didn't happen and tests failed.

Typescript didn't like `event.hasOwnProperty('code')` so I used `prop in obj` instead, although it's less safe, but didn't want to use `@ts-ignore`. What do you think? Would it be better to use hasOwnProperty and add `@ts-ignore`.?